### PR TITLE
Fix certain save files that didn't work

### DIFF
--- a/wts_infinite_myaile.py
+++ b/wts_infinite_myaile.py
@@ -4,7 +4,12 @@ from io import BytesIO
 import os
 
 SAVEDATA_HEADER = b"BX30"
-SAVEDATA_MYAILE_COUNT_POSITION = 0x286b
+
+SAVEDATA_MYAILE_COUNT_ENTRY_1 = 0x2871
+SAVEDATA_MYAILE_COUNT_ENTRY_2 = 0x2869
+
+SAVEDATA_MYAILE_COUNT_POSITION_1 = 0x2873
+SAVEDATA_MYAILE_COUNT_POSITION_2 = 0x286B
 
 GET_MYAILE_COUNT_ACTION = "wts_infinite_myaile.api_endpoint.get_myaile_count"
 UPDATE_MYAILE_COUNT_ACTION = "wts_infinite_myaile.api_endpoint.update_myaile_count"
@@ -36,16 +41,42 @@ def api_endpoint():
     action = request.form.get("action")
 
     if action == GET_MYAILE_COUNT_ACTION:
-        savedata.seek(SAVEDATA_MYAILE_COUNT_POSITION, os.SEEK_SET)
+        savedata.seek(SAVEDATA_MYAILE_COUNT_ENTRY_1, os.SEEK_SET)
+        byte = savedata.read(1)
+        if byte == b' ':
+            savedata.seek(SAVEDATA_MYAILE_COUNT_POSITION_1, os.SEEK_SET)
+        else:
+            savedata.seek(SAVEDATA_MYAILE_COUNT_ENTRY_2, os.SEEK_SET)
+            byte = savedata.read(1)
+            if byte == b' ':
+                savedata.seek(SAVEDATA_MYAILE_COUNT_POSITION_2, os.SEEK_SET)
+            else:
+                return {"message": "invalid savedata provided"}, 400
+        
         myaile_count = int.from_bytes(savedata.read(2), "big", signed=True)
 
         return {"myaile_count": myaile_count}
 
     if action == UPDATE_MYAILE_COUNT_ACTION:
+        actual_pos = 0
+    
+        savedata.seek(SAVEDATA_MYAILE_COUNT_ENTRY_1, os.SEEK_SET)
+        byte = savedata.read(1)
+        if byte == b' ':
+            actual_pos = SAVEDATA_MYAILE_COUNT_POSITION_1
+        else:
+            savedata.seek(SAVEDATA_MYAILE_COUNT_ENTRY_2, os.SEEK_SET)
+            byte = savedata.read(1)
+            if byte == b' ':
+                actual_pos = SAVEDATA_MYAILE_COUNT_POSITION_2
+            else:
+                return {"message": "invalid savedata provided"}, 400
+        
+        
         savedata.seek(0, os.SEEK_SET)
         updated_savedata = BytesIO()
 
-        updated_savedata.write(savedata.read(SAVEDATA_MYAILE_COUNT_POSITION))
+        updated_savedata.write(savedata.read(actual_pos))
         updated_savedata.write(MAXIMUM_MYAILE_COUNT.to_bytes(2, "big", signed=True))
 
         savedata.seek(2, os.SEEK_CUR)


### PR DESCRIPTION
Fixed a bug that broke some saves with this tool. The save file format flip flopped around 0x2873 and 0x286B for the current amount of myaile offset so I wrote a check that should work every single time.